### PR TITLE
Don't delete clips after archiving

### DIFF
--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -9,17 +9,17 @@ FILE_COUNT=$(cd "$CAM_MOUNT" && find . -maxdepth 4 -path './TeslaCam/SavedClips/
 if [ -d "$CAM_MOUNT"/TeslaCam/SavedClips ]
 then
   # shellcheck disable=SC2154
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SavedClips "$drive:$path"/SavedClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
+  rclone --config /root/.config/rclone/rclone.conf copy "$CAM_MOUNT"/TeslaCam/SavedClips "$drive:$path"/SavedClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
 fi
 
 if [ -d "$CAM_MOUNT"/TeslaCam/SentryClips ]
 then
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaCam/SentryClips "$drive:$path"/SentryClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
+  rclone --config /root/.config/rclone/rclone.conf copy "$CAM_MOUNT"/TeslaCam/SentryClips "$drive:$path"/SentryClips/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
 fi
 
 if [ -d "$CAM_MOUNT"/TeslaTrackMode ]
 then
-  rclone --config /root/.config/rclone/rclone.conf move "$CAM_MOUNT"/TeslaTrackMode "$drive:$path"/TeslaTrackMode/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
+  rclone --config /root/.config/rclone/rclone.conf copy "$CAM_MOUNT"/TeslaTrackMode "$drive:$path"/TeslaTrackMode/ --create-empty-src-dirs --delete-empty-src-dirs >> "$LOG_FILE" 2>&1 || echo ""
 fi
 
 FILES_REMAINING=$(cd "$CAM_MOUNT" && find . -maxdepth 4 -path './TeslaCam/SavedClips/*' -type f -o -path './TeslaCam/SentryClips/*' -type f -o -path './TeslaTrackMode' -type f | wc -l)

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -5,7 +5,7 @@ log "Archiving through rsync..."
 source /root/.teslaCamRsyncConfig
 
 # shellcheck disable=SC2154
-num_files_moved=$(rsync -auvh --timeout=60 --remove-source-files --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log "$CAM_MOUNT/TeslaCam/SentryClips/"* "$CAM_MOUNT/TeslaCam/SavedClips/"* "$CAM_MOUNT/TeslaTrackMode" "$user@$server:$path" | awk '/files transferred/{print $NF}')
+num_files_moved=$(rsync -auvh --timeout=60 --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log "$CAM_MOUNT/TeslaCam/SentryClips/"* "$CAM_MOUNT/TeslaCam/SavedClips/"* "$CAM_MOUNT/TeslaTrackMode" "$user@$server:$path" | awk '/files transferred/{print $NF}')
 
 if (( num_files_moved > 0 ))
 then


### PR DESCRIPTION
The car can manage its own storage now, and leaving the clips on the card allows using the car's dashcam viewer to view them even after archiving.